### PR TITLE
Update libVersion to fix build issues

### DIFF
--- a/app/src/main/java/dev/brahmkshatriya/echo/extension/AndroidED.kt
+++ b/app/src/main/java/dev/brahmkshatriya/echo/extension/AndroidED.kt
@@ -58,13 +58,14 @@ class AndroidED : EDExtension() {
     ): File {
         val file = getDownloadDir(context)
         return when (source) {
-            is Streamable.Source.ByteStream -> {
+            is Streamable.Source.Raw -> {
                 val preFile = File(file.parent, "${source.hashCode()}.mp3")
+                val (stream, totalBytes) = source.streamProvider.provide(0, -1)
                 inputStreamDownload.inputStreamDownload(
                     preFile,
                     progressFlow,
-                    source.stream,
-                    source.totalBytes
+                    stream,
+                    totalBytes
                 )
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 
-libVersion=ba301d9f1c
+libVersion=d1eeb8a34f
 
 # Can be music, tracker or lyrics
 extType=misc


### PR DESCRIPTION
To fix gradle build; apparently, d1eeb8a34f is unavailable in jitpack anymore? (or was i simply lacking rights?)
Anyway, now it builds
There have been some changes in API, reflected them here as well

Before
<img width="687" height="138" alt="image" src="https://github.com/user-attachments/assets/58c5ac95-4f75-4fe5-885b-ae8c729026b6" />

After

<img width="483" height="95" alt="image" src="https://github.com/user-attachments/assets/486d6e59-1f46-4e87-a280-d9f4b6c9302a" />

